### PR TITLE
Add privacy manifest references to podspec

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -3,6 +3,10 @@ All notable changes to the Chartbeat iOS SDK  will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [1.5.3] - 2024-04-24
+### Added
+- Added Privacy Manifest references to podspec file
+
 ## [1.5.2] - 2024-01-24
 ### Added
 - Added Privacy Manifest

--- a/Chartbeat.podspec
+++ b/Chartbeat.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.summary                 = "This is the Chartbeat iOS SDK -- providing a library for iOS applications so they can send tracking events to Chartbeat."
   s.requires_arc            = true
 
-  s.version                 = "1.5.2"
+  s.version                 = "1.5.3"
 
   s.license                 = { :type => "MIT", :file => "LICENSE" }
 
@@ -14,6 +14,7 @@ Pod::Spec.new do |s|
   s.homepage                = "https://chartbeat.com/"
 
   s.vendored_frameworks     = "Chartbeat.xcframework"
+  s.resource_bundles        = {'Chartbeat_Privacy' => ['PrivacyInfo.xcprivacy']}
   s.source                  = { :git => "https://github.com/chartbeat-labs/chartbeat-ios-sdk.git", :tag => "1.5.2" }
 
   s.frameworks              = 'SystemConfiguration', 'MediaPlayer'


### PR DESCRIPTION
Currently our privacy manifest file stays in source but not in the bundle when client installs it from cocoapods. I added references in podspec file based on suggestion here https://forums.developer.apple.com/forums/thread/745546.

Gonna have client to verify once it is merged and pushed